### PR TITLE
[FEAT] 캘린더 월 별 공부 기록 조회 기능 추가

### DIFF
--- a/src/main/java/com/woohaengshi/backend/controller/StudyRecordController.java
+++ b/src/main/java/com/woohaengshi/backend/controller/StudyRecordController.java
@@ -8,8 +8,11 @@ import jakarta.validation.Valid;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.YearMonth;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,7 +29,7 @@ public class StudyRecordController {
 
     @GetMapping("/monthly")
     public ShowMonthlyRecordResponse getMonthlyRecords(
-            @RequestParam("year") int year, @RequestParam("month") int month) {
-        return studyRecordService.showMonthlyRecord(year, month, 1L);
+            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM") YearMonth date) {
+        return studyRecordService.showMonthlyRecord(date, 1L);
     }
 }

--- a/src/main/java/com/woohaengshi/backend/controller/StudyRecordController.java
+++ b/src/main/java/com/woohaengshi/backend/controller/StudyRecordController.java
@@ -1,6 +1,7 @@
 package com.woohaengshi.backend.controller;
 
 import com.woohaengshi.backend.dto.request.studyrecord.SaveRecordRequest;
+import com.woohaengshi.backend.service.studyrecord.StudyRecordService;
 import com.woohaengshi.backend.service.studyrecord.StudyRecordServiceImpl;
 
 import jakarta.validation.Valid;
@@ -8,10 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -20,11 +18,11 @@ import java.net.URI;
 @RequestMapping("/api/v1/study-record")
 public class StudyRecordController {
 
-    private final StudyRecordServiceImpl studyRecordServiceImpl;
+    private final StudyRecordService studyRecordService;
 
     @PostMapping
     public ResponseEntity<Void> saveStudyRecord(@Valid @RequestBody SaveRecordRequest request) {
-        studyRecordServiceImpl.save(request, 1L);
+        studyRecordService.save(request, 1L);
         return ResponseEntity.created(URI.create("/api/v1/timers")).build();
     }
 }

--- a/src/main/java/com/woohaengshi/backend/controller/StudyRecordController.java
+++ b/src/main/java/com/woohaengshi/backend/controller/StudyRecordController.java
@@ -1,6 +1,7 @@
 package com.woohaengshi.backend.controller;
 
 import com.woohaengshi.backend.dto.request.studyrecord.SaveRecordRequest;
+import com.woohaengshi.backend.dto.response.studyrecord.ShowMonthlyRecordResponse;
 import com.woohaengshi.backend.service.studyrecord.StudyRecordService;
 import com.woohaengshi.backend.service.studyrecord.StudyRecordServiceImpl;
 
@@ -24,5 +25,10 @@ public class StudyRecordController {
     public ResponseEntity<Void> saveStudyRecord(@Valid @RequestBody SaveRecordRequest request) {
         studyRecordService.save(request, 1L);
         return ResponseEntity.created(URI.create("/api/v1/timers")).build();
+    }
+
+    @GetMapping("/monthly")
+    public ShowMonthlyRecordResponse getMonthlyRecords(int year, int month) {
+        return studyRecordService.showMonthlyRecord(year, month, 1L);
     }
 }

--- a/src/main/java/com/woohaengshi/backend/controller/StudyRecordController.java
+++ b/src/main/java/com/woohaengshi/backend/controller/StudyRecordController.java
@@ -1,7 +1,7 @@
 package com.woohaengshi.backend.controller;
 
 import com.woohaengshi.backend.dto.request.studyrecord.SaveRecordRequest;
-import com.woohaengshi.backend.service.StudyRecordService;
+import com.woohaengshi.backend.service.studyrecord.StudyRecordServiceImpl;
 
 import jakarta.validation.Valid;
 
@@ -20,11 +20,11 @@ import java.net.URI;
 @RequestMapping("/api/v1/study-record")
 public class StudyRecordController {
 
-    private final StudyRecordService studyRecordService;
+    private final StudyRecordServiceImpl studyRecordServiceImpl;
 
     @PostMapping
     public ResponseEntity<Void> saveStudyRecord(@Valid @RequestBody SaveRecordRequest request) {
-        studyRecordService.save(request, 1L);
+        studyRecordServiceImpl.save(request, 1L);
         return ResponseEntity.created(URI.create("/api/v1/timers")).build();
     }
 }

--- a/src/main/java/com/woohaengshi/backend/controller/StudyRecordController.java
+++ b/src/main/java/com/woohaengshi/backend/controller/StudyRecordController.java
@@ -3,7 +3,6 @@ package com.woohaengshi.backend.controller;
 import com.woohaengshi.backend.dto.request.studyrecord.SaveRecordRequest;
 import com.woohaengshi.backend.dto.response.studyrecord.ShowMonthlyRecordResponse;
 import com.woohaengshi.backend.service.studyrecord.StudyRecordService;
-import com.woohaengshi.backend.service.studyrecord.StudyRecordServiceImpl;
 
 import jakarta.validation.Valid;
 

--- a/src/main/java/com/woohaengshi/backend/controller/StudyRecordController.java
+++ b/src/main/java/com/woohaengshi/backend/controller/StudyRecordController.java
@@ -27,7 +27,8 @@ public class StudyRecordController {
     }
 
     @GetMapping("/monthly")
-    public ShowMonthlyRecordResponse getMonthlyRecords(int year, int month) {
+    public ShowMonthlyRecordResponse getMonthlyRecords(
+            @RequestParam("year") int year, @RequestParam("month") int month) {
         return studyRecordService.showMonthlyRecord(year, month, 1L);
     }
 }

--- a/src/main/java/com/woohaengshi/backend/controller/TimerController.java
+++ b/src/main/java/com/woohaengshi/backend/controller/TimerController.java
@@ -1,6 +1,6 @@
 package com.woohaengshi.backend.controller;
 
-import com.woohaengshi.backend.dto.response.studyrecord.ShowTimerResponse;
+import com.woohaengshi.backend.dto.response.timer.ShowTimerResponse;
 import com.woohaengshi.backend.service.timer.TimerService;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowDailyRecordResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowDailyRecordResponse.java
@@ -1,0 +1,25 @@
+package com.woohaengshi.backend.dto.response.studyrecord;
+
+import com.woohaengshi.backend.domain.Subject;
+import com.woohaengshi.backend.dto.response.subject.ShowSubjectsResponse;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ShowDailyRecordResponse {
+    private int day;
+    private int time;
+    private List<ShowSubjectsResponse> subjects;
+
+    private ShowDailyRecordResponse(int day, int time, List<ShowSubjectsResponse> subjects) {
+        this.day = day;
+        this.time = time;
+        this.subjects = subjects;
+    }
+
+    public static ShowDailyRecordResponse of(int day, int time, List<Subject> subjects) {
+        return new ShowDailyRecordResponse(
+                day, time, subjects.stream().map(ShowSubjectsResponse::from).toList());
+    }
+}

--- a/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowDailyRecordResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowDailyRecordResponse.java
@@ -2,6 +2,7 @@ package com.woohaengshi.backend.dto.response.studyrecord;
 
 import com.woohaengshi.backend.domain.Subject;
 import com.woohaengshi.backend.dto.response.subject.ShowSubjectsResponse;
+
 import lombok.Getter;
 
 import java.util.List;

--- a/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowDailyRecordResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowDailyRecordResponse.java
@@ -19,8 +19,8 @@ public class ShowDailyRecordResponse {
         this.subjects = subjects;
     }
 
-    public static ShowDailyRecordResponse of(int day, int time, List<Subject> subjects) {
-        return new ShowDailyRecordResponse(
-                day, time, subjects.stream().map(ShowSubjectsResponse::from).toList());
+    public static ShowDailyRecordResponse of(
+            int day, int time, List<ShowSubjectsResponse> subjects) {
+        return new ShowDailyRecordResponse(day, time, subjects);
     }
 }

--- a/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowDailyRecordResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowDailyRecordResponse.java
@@ -1,6 +1,5 @@
 package com.woohaengshi.backend.dto.response.studyrecord;
 
-import com.woohaengshi.backend.domain.Subject;
 import com.woohaengshi.backend.dto.response.subject.ShowSubjectsResponse;
 
 import lombok.Getter;

--- a/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
@@ -1,0 +1,38 @@
+package com.woohaengshi.backend.dto.response.studyrecord;
+
+import com.woohaengshi.backend.domain.Subject;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class ShowMonthlyRecordResponse {
+    private int year;
+    private int month;
+    private List<ShowDailyRecordResponse> daily;
+
+    private ShowMonthlyRecordResponse(int year, int month, List<ShowDailyRecordResponse> daily) {
+        this.year = year;
+        this.month = month;
+        this.daily = daily;
+    }
+
+    public static ShowMonthlyRecordResponse of(int year, int month, List<Object[]> records) {
+        return new ShowMonthlyRecordResponse(
+                year,
+                month,
+                records.stream()
+                        .map(
+                                record ->
+                                        ShowDailyRecordResponse.of(
+                                                ((Number) record[0]).intValue(),
+                                                ((Number) record[1]).intValue(),
+                                                List.of(
+                                                        Subject.builder()
+                                                                .id((Long) record[2])
+                                                                .name((String) record[3])
+                                                                .build())))
+                        .collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
@@ -1,6 +1,7 @@
 package com.woohaengshi.backend.dto.response.studyrecord;
 
 import com.woohaengshi.backend.domain.Subject;
+
 import lombok.Getter;
 
 import java.util.List;

--- a/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
@@ -1,8 +1,8 @@
 package com.woohaengshi.backend.dto.response.studyrecord;
 
 import com.woohaengshi.backend.domain.Subject;
-
 import com.woohaengshi.backend.dto.response.subject.ShowSubjectsResponse;
+
 import lombok.Getter;
 
 import java.time.YearMonth;

--- a/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
@@ -2,8 +2,10 @@ package com.woohaengshi.backend.dto.response.studyrecord;
 
 import com.woohaengshi.backend.domain.Subject;
 
+import com.woohaengshi.backend.dto.response.subject.ShowSubjectsResponse;
 import lombok.Getter;
 
+import java.time.YearMonth;
 import java.util.List;
 
 @Getter
@@ -18,10 +20,10 @@ public class ShowMonthlyRecordResponse {
         this.daily = daily;
     }
 
-    public static ShowMonthlyRecordResponse of(int year, int month, List<Object[]> records) {
+    public static ShowMonthlyRecordResponse of(YearMonth date, List<Object[]> records) {
         return new ShowMonthlyRecordResponse(
-                year,
-                month,
+                date.getYear(),
+                date.getMonthValue(),
                 records.stream()
                         .map(
                                 record ->
@@ -29,10 +31,11 @@ public class ShowMonthlyRecordResponse {
                                                 ((Number) record[0]).intValue(),
                                                 ((Number) record[1]).intValue(),
                                                 List.of(
-                                                        Subject.builder()
-                                                                .id((Long) record[2])
-                                                                .name((String) record[3])
-                                                                .build())))
+                                                        ShowSubjectsResponse.from(
+                                                                Subject.builder()
+                                                                        .id((Long) record[2])
+                                                                        .name((String) record[3])
+                                                                        .build()))))
                         .toList());
     }
 }

--- a/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
@@ -4,7 +4,6 @@ import com.woohaengshi.backend.domain.Subject;
 import lombok.Getter;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 public class ShowMonthlyRecordResponse {
@@ -33,6 +32,6 @@ public class ShowMonthlyRecordResponse {
                                                                 .id((Long) record[2])
                                                                 .name((String) record[3])
                                                                 .build())))
-                        .collect(Collectors.toList()));
+                        .toList());
     }
 }

--- a/src/main/java/com/woohaengshi/backend/dto/response/timer/ShowTimerResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/timer/ShowTimerResponse.java
@@ -1,4 +1,4 @@
-package com.woohaengshi.backend.dto.response.studyrecord;
+package com.woohaengshi.backend.dto.response.timer;
 
 import com.woohaengshi.backend.domain.Subject;
 import com.woohaengshi.backend.dto.response.subject.ShowSubjectsResponse;

--- a/src/main/java/com/woohaengshi/backend/repository/StudyRecordRepository.java
+++ b/src/main/java/com/woohaengshi/backend/repository/StudyRecordRepository.java
@@ -15,9 +15,9 @@ public interface StudyRecordRepository extends JpaRepository<StudyRecord, Long> 
 
     @Query(
             value =
-                    "SELECT DAY(r.date), r.time, sb.id, sb.subject_name\n"
-                            + "FROM studyrecord r\n"
-                            + "INNER JOIN studysubject st ON r.study_id = st.study_id\n"
+                    "SELECT DAY(r.date), r.time, sb.id, sb.name\n"
+                            + "FROM study_record r\n"
+                            + "INNER JOIN study_subject st ON r.id = st.study_record_id\n"
                             + "INNER JOIN subject sb ON st.subject_id = sb.id\n"
                             + "WHERE YEAR(r.date) = :year\n"
                             + "  AND MONTH(r.date) = :month\n"

--- a/src/main/java/com/woohaengshi/backend/repository/StudyRecordRepository.java
+++ b/src/main/java/com/woohaengshi/backend/repository/StudyRecordRepository.java
@@ -3,10 +3,29 @@ package com.woohaengshi.backend.repository;
 import com.woohaengshi.backend.domain.StudyRecord;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface StudyRecordRepository extends JpaRepository<StudyRecord, Long> {
     Optional<StudyRecord> findByDateAndMemberId(LocalDate date, Long memberId);
+
+    @Query(
+            value =
+                    "SELECT DAY(r.date), r.time, sb.id, sb.subject_name\n"
+                            + "FROM studyrecord r\n"
+                            + "INNER JOIN studysubject st ON r.study_id = st.study_id\n"
+                            + "INNER JOIN subject sb ON st.subject_id = sb.id\n"
+                            + "WHERE YEAR(r.date) = :year\n"
+                            + "  AND MONTH(r.date) = :month\n"
+                            + "  AND r.member_id = :memberId\n"
+                            + "ORDER BY r.date ASC;",
+            nativeQuery = true)
+    List<Object[]> findByYearAndMonthAndMemberId(
+            @Param(value = "year") int year,
+            @Param(value = "month") int month,
+            @Param(value = "memberId") Long memberId);
 }

--- a/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordService.java
+++ b/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordService.java
@@ -3,8 +3,10 @@ package com.woohaengshi.backend.service.studyrecord;
 import com.woohaengshi.backend.dto.request.studyrecord.SaveRecordRequest;
 import com.woohaengshi.backend.dto.response.studyrecord.ShowMonthlyRecordResponse;
 
+import java.time.YearMonth;
+
 public interface StudyRecordService {
     public void save(SaveRecordRequest request, Long memberId);
 
-    public ShowMonthlyRecordResponse showMonthlyRecord(int year, int month, Long memberId);
+    public ShowMonthlyRecordResponse showMonthlyRecord(YearMonth date, Long memberId);
 }

--- a/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordService.java
+++ b/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordService.java
@@ -1,7 +1,10 @@
 package com.woohaengshi.backend.service.studyrecord;
 
 import com.woohaengshi.backend.dto.request.studyrecord.SaveRecordRequest;
+import com.woohaengshi.backend.dto.response.studyrecord.ShowMonthlyRecordResponse;
 
 public interface StudyRecordService {
     public void save(SaveRecordRequest request, Long memberId);
+
+    public ShowMonthlyRecordResponse showMonthlyRecord(int year, int month, Long memberId);
 }

--- a/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordService.java
+++ b/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordService.java
@@ -1,0 +1,7 @@
+package com.woohaengshi.backend.service.studyrecord;
+
+import com.woohaengshi.backend.dto.request.studyrecord.SaveRecordRequest;
+
+public interface StudyRecordService {
+    public void save(SaveRecordRequest request, Long memberId);
+}

--- a/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
+++ b/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
@@ -1,4 +1,4 @@
-package com.woohaengshi.backend.service;
+package com.woohaengshi.backend.service.studyrecord;
 
 import com.woohaengshi.backend.domain.StudyRecord;
 import com.woohaengshi.backend.domain.Subject;
@@ -21,7 +21,7 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class StudyRecordService {
+public class StudyRecordServiceImpl implements StudyRecordService {
 
     private final MemberRepository memberRepository;
     private final StudyRecordRepository studyRecordRepository;

--- a/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
+++ b/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
@@ -28,7 +28,7 @@ public class StudyRecordServiceImpl implements StudyRecordService {
     private final StudyRecordRepository studyRecordRepository;
     private final SubjectRepository subjectRepository;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public void save(SaveRecordRequest request, Long memberId) {
         validateExistMember(memberId);
         Optional<StudyRecord> optionalStudyRecord =

--- a/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
+++ b/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
@@ -50,7 +50,8 @@ public class StudyRecordServiceImpl implements StudyRecordService {
 
         return ShowMonthlyRecordResponse.of(
                 date,
-                studyRecordRepository.findByYearAndMonthAndMemberId(date.getYear(), date.getMonthValue(), memberId));
+                studyRecordRepository.findByYearAndMonthAndMemberId(
+                        date.getYear(), date.getMonthValue(), memberId));
     }
 
     private void validateExistMember(Long memberId) {

--- a/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
+++ b/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
@@ -1,14 +1,18 @@
 package com.woohaengshi.backend.service.studyrecord;
 
+import static com.woohaengshi.backend.exception.ErrorCode.MEMBER_NOT_FOUND;
+import static com.woohaengshi.backend.exception.ErrorCode.SUBJECT_NOT_FOUND;
+
 import com.woohaengshi.backend.domain.StudyRecord;
+import com.woohaengshi.backend.domain.StudySubject;
 import com.woohaengshi.backend.domain.Subject;
 import com.woohaengshi.backend.domain.member.Member;
 import com.woohaengshi.backend.dto.request.studyrecord.SaveRecordRequest;
 import com.woohaengshi.backend.dto.response.studyrecord.ShowMonthlyRecordResponse;
-import com.woohaengshi.backend.exception.ErrorCode;
 import com.woohaengshi.backend.exception.WoohaengshiException;
 import com.woohaengshi.backend.repository.MemberRepository;
 import com.woohaengshi.backend.repository.StudyRecordRepository;
+import com.woohaengshi.backend.repository.StudySubjectRepository;
 import com.woohaengshi.backend.repository.SubjectRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -20,15 +24,16 @@ import java.util.List;
 import java.util.Optional;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
+@Transactional
 public class StudyRecordServiceImpl implements StudyRecordService {
 
     private final MemberRepository memberRepository;
     private final StudyRecordRepository studyRecordRepository;
     private final SubjectRepository subjectRepository;
+    private final StudySubjectRepository studySubjectRepository;
 
-    @Transactional
+    @Override
     public void save(SaveRecordRequest request, Long memberId) {
         validateExistMember(memberId);
         Optional<StudyRecord> optionalStudyRecord =
@@ -37,6 +42,7 @@ public class StudyRecordServiceImpl implements StudyRecordService {
         saveSubjects(request.getSubjects(), studyRecord);
     }
 
+    @Override
     @Transactional(readOnly = true)
     public ShowMonthlyRecordResponse showMonthlyRecord(int year, int month, Long memberId) {
         validateExistMember(memberId);
@@ -48,7 +54,7 @@ public class StudyRecordServiceImpl implements StudyRecordService {
 
     private void validateExistMember(Long memberId) {
         if (!memberRepository.existsById(memberId))
-            throw new WoohaengshiException(ErrorCode.MEMBER_NOT_FOUND);
+            throw new WoohaengshiException(MEMBER_NOT_FOUND);
     }
 
     private StudyRecord saveStudyRecord(
@@ -61,26 +67,29 @@ public class StudyRecordServiceImpl implements StudyRecordService {
         return studyRecordRepository.save(request.toStudyRecord(findMemberById(memberId)));
     }
 
-    private void saveSubjects(List<String> subjects, StudyRecord studyRecord) {
-        subjects.forEach(
-                subject -> {
-                    if (!subjectRepository.existsByNameAndStudyRecordId(
-                            subject, studyRecord.getId()))
-                        subjectRepository.save(createSubject(studyRecord, subject));
-                });
+    private void saveSubjects(List<Long> subjects, StudyRecord studyRecord) {
+        for (Long subjectId : subjects) {
+            if (!studySubjectRepository.existsBySubjectIdAndStudyRecordId(
+                    subjectId, studyRecord.getId())) {
+                Subject subject = findSubjectById(subjectId);
+                studySubjectRepository.save(createStudySubject(studyRecord, subject));
+            }
+        }
     }
 
-    private Subject createSubject(StudyRecord studyRecord, String subject) {
-        return Subject.builder()
-                .name(subject)
-                .studyRecord(studyRecord)
-                .member(studyRecord.getMember())
-                .build();
+    private Subject findSubjectById(Long subjectId) {
+        return subjectRepository
+                .findById(subjectId)
+                .orElseThrow(() -> new WoohaengshiException(SUBJECT_NOT_FOUND));
+    }
+
+    private StudySubject createStudySubject(StudyRecord studyRecord, Subject subject) {
+        return StudySubject.builder().subject(subject).studyRecord(studyRecord).build();
     }
 
     private Member findMemberById(Long memberId) {
         return memberRepository
                 .findById(memberId)
-                .orElseThrow(() -> new WoohaengshiException(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new WoohaengshiException(MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
+++ b/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
@@ -47,13 +47,10 @@ public class StudyRecordServiceImpl implements StudyRecordService {
     @Transactional(readOnly = true)
     public ShowMonthlyRecordResponse showMonthlyRecord(YearMonth date, Long memberId) {
         validateExistMember(memberId);
-        int year = date.getYear();
-        int month = date.getMonthValue();
 
         return ShowMonthlyRecordResponse.of(
-                year,
-                month,
-                studyRecordRepository.findByYearAndMonthAndMemberId(year, month, memberId));
+                date,
+                studyRecordRepository.findByYearAndMonthAndMemberId(date.getYear(), date.getMonthValue(), memberId));
     }
 
     private void validateExistMember(Long memberId) {

--- a/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
+++ b/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
@@ -19,15 +19,15 @@ import java.util.List;
 import java.util.Optional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class StudyRecordServiceImpl implements StudyRecordService {
 
     private final MemberRepository memberRepository;
     private final StudyRecordRepository studyRecordRepository;
     private final SubjectRepository subjectRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public void save(SaveRecordRequest request, Long memberId) {
         validateExistMember(memberId);
         Optional<StudyRecord> optionalStudyRecord =

--- a/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
+++ b/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,8 +45,11 @@ public class StudyRecordServiceImpl implements StudyRecordService {
 
     @Override
     @Transactional(readOnly = true)
-    public ShowMonthlyRecordResponse showMonthlyRecord(int year, int month, Long memberId) {
+    public ShowMonthlyRecordResponse showMonthlyRecord(YearMonth date, Long memberId) {
         validateExistMember(memberId);
+        int year = date.getYear();
+        int month = date.getMonthValue();
+
         return ShowMonthlyRecordResponse.of(
                 year,
                 month,

--- a/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
+++ b/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
@@ -4,6 +4,7 @@ import com.woohaengshi.backend.domain.StudyRecord;
 import com.woohaengshi.backend.domain.Subject;
 import com.woohaengshi.backend.domain.member.Member;
 import com.woohaengshi.backend.dto.request.studyrecord.SaveRecordRequest;
+import com.woohaengshi.backend.dto.response.studyrecord.ShowMonthlyRecordResponse;
 import com.woohaengshi.backend.exception.ErrorCode;
 import com.woohaengshi.backend.exception.WoohaengshiException;
 import com.woohaengshi.backend.repository.MemberRepository;
@@ -34,6 +35,15 @@ public class StudyRecordServiceImpl implements StudyRecordService {
                 studyRecordRepository.findByDateAndMemberId(request.getDate(), memberId);
         StudyRecord studyRecord = saveStudyRecord(request, memberId, optionalStudyRecord);
         saveSubjects(request.getSubjects(), studyRecord);
+    }
+
+    @Transactional(readOnly = true)
+    public ShowMonthlyRecordResponse showMonthlyRecord(int year, int month, Long memberId) {
+        validateExistMember(memberId);
+        return ShowMonthlyRecordResponse.of(
+                year,
+                month,
+                studyRecordRepository.findByYearAndMonthAndMemberId(year, month, memberId));
     }
 
     private void validateExistMember(Long memberId) {

--- a/src/main/java/com/woohaengshi/backend/service/timer/TimerService.java
+++ b/src/main/java/com/woohaengshi/backend/service/timer/TimerService.java
@@ -1,6 +1,6 @@
 package com.woohaengshi.backend.service.timer;
 
-import com.woohaengshi.backend.dto.response.studyrecord.ShowTimerResponse;
+import com.woohaengshi.backend.dto.response.timer.ShowTimerResponse;
 
 public interface TimerService {
     ShowTimerResponse getTimer(Long memberId);

--- a/src/main/java/com/woohaengshi/backend/service/timer/TimerServiceImpl.java
+++ b/src/main/java/com/woohaengshi/backend/service/timer/TimerServiceImpl.java
@@ -3,7 +3,7 @@ package com.woohaengshi.backend.service.timer;
 import com.woohaengshi.backend.constant.StandardTimeConstant;
 import com.woohaengshi.backend.domain.StudyRecord;
 import com.woohaengshi.backend.domain.Subject;
-import com.woohaengshi.backend.dto.response.studyrecord.ShowTimerResponse;
+import com.woohaengshi.backend.dto.response.timer.ShowTimerResponse;
 import com.woohaengshi.backend.exception.ErrorCode;
 import com.woohaengshi.backend.exception.WoohaengshiException;
 import com.woohaengshi.backend.repository.MemberRepository;

--- a/src/test/java/com/woohaengshi/backend/controller/StatisticsControllerTest.java
+++ b/src/test/java/com/woohaengshi/backend/controller/StatisticsControllerTest.java
@@ -1,6 +1,5 @@
 package com.woohaengshi.backend.controller;
 
-
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 

--- a/src/test/java/com/woohaengshi/backend/controller/StudyRecordControllerTest.java
+++ b/src/test/java/com/woohaengshi/backend/controller/StudyRecordControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -78,15 +79,11 @@ class StudyRecordControllerTest {
 
     @Test
     void 연도와_월을_통해_공부_기록을_조회할_수_있다() {
-        int year = 2024;
-        int month = 8;
-
         RestAssured.given()
                 .log()
                 .all()
                 .contentType(ContentType.JSON)
-                .queryParam("year", year)
-                .queryParam("month", month)
+                .queryParam("date", YearMonth.now().toString())
                 .when()
                 .get("/api/v1/study-record/monthly")
                 .then()
@@ -96,31 +93,11 @@ class StudyRecordControllerTest {
     }
 
     @Test
-    void 월이_전달되지_않으면_공부_기록을_조회할_수_없다() {
-        int year = 2024;
-
+    void 날짜가_전달되지_않으면_공부_기록을_조회할_수_없다() {
         RestAssured.given()
                 .log()
                 .all()
                 .contentType(ContentType.JSON)
-                .queryParam("year", year)
-                .when()
-                .get("/api/v1/study-record/monthly")
-                .then()
-                .log()
-                .all()
-                .statusCode(BAD_REQUEST.value());
-    }
-
-    @Test
-    void 연도가_전달되지_않으면_공부_기록을_조회할_수_없다() {
-        int month = 8;
-
-        RestAssured.given()
-                .log()
-                .all()
-                .contentType(ContentType.JSON)
-                .queryParam("month", month)
                 .when()
                 .get("/api/v1/study-record/monthly")
                 .then()

--- a/src/test/java/com/woohaengshi/backend/controller/StudyRecordControllerTest.java
+++ b/src/test/java/com/woohaengshi/backend/controller/StudyRecordControllerTest.java
@@ -72,4 +72,57 @@ class StudyRecordControllerTest {
                 .all()
                 .statusCode(400);
     }
+
+    @Test
+    void 연도와_월을_통해_공부_기록을_조회할_수_있다() {
+        int year = 2024;
+        int month = 8;
+
+        RestAssured.given()
+                .log()
+                .all()
+                .contentType(ContentType.JSON)
+                .queryParam("year", year)
+                .queryParam("month", month)
+                .when()
+                .get("/api/v1/study-record/monthly")
+                .then()
+                .log()
+                .all()
+                .statusCode(200);
+    }
+
+    @Test
+    void 월이_전달되지_않으면_공부_기록을_조회할_수_없다() {
+        int year = 2024;
+
+        RestAssured.given()
+                .log()
+                .all()
+                .contentType(ContentType.JSON)
+                .queryParam("year", year)
+                .when()
+                .get("/api/v1/study-record/monthly")
+                .then()
+                .log()
+                .all()
+                .statusCode(400);
+    }
+
+    @Test
+    void 연도가_전달되지_않으면_공부_기록을_조회할_수_없다() {
+        int month = 8;
+
+        RestAssured.given()
+                .log()
+                .all()
+                .contentType(ContentType.JSON)
+                .queryParam("month", month)
+                .when()
+                .get("/api/v1/study-record/monthly")
+                .then()
+                .log()
+                .all()
+                .statusCode(400);
+    }
 }

--- a/src/test/java/com/woohaengshi/backend/controller/StudyRecordControllerTest.java
+++ b/src/test/java/com/woohaengshi/backend/controller/StudyRecordControllerTest.java
@@ -2,6 +2,7 @@ package com.woohaengshi.backend.controller;
 
 import static com.woohaengshi.backend.exception.ErrorCode.INVALID_INPUT;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.OK;
 
 import com.woohaengshi.backend.dto.request.studyrecord.SaveRecordRequest;
@@ -91,7 +92,7 @@ class StudyRecordControllerTest {
                 .then()
                 .log()
                 .all()
-                .statusCode(200);
+                .statusCode(OK.value());
     }
 
     @Test
@@ -108,7 +109,7 @@ class StudyRecordControllerTest {
                 .then()
                 .log()
                 .all()
-                .statusCode(400);
+                .statusCode(BAD_REQUEST.value());
     }
 
     @Test
@@ -125,6 +126,6 @@ class StudyRecordControllerTest {
                 .then()
                 .log()
                 .all()
-                .statusCode(400);
+                .statusCode(BAD_REQUEST.value());
     }
 }

--- a/src/test/java/com/woohaengshi/backend/repository/StudyRecordRepositoryTest.java
+++ b/src/test/java/com/woohaengshi/backend/repository/StudyRecordRepositoryTest.java
@@ -1,0 +1,111 @@
+package com.woohaengshi.backend.repository;
+
+import com.woohaengshi.backend.domain.StudyRecord;
+import com.woohaengshi.backend.domain.StudySubject;
+import com.woohaengshi.backend.domain.Subject;
+import com.woohaengshi.backend.domain.member.Course;
+import com.woohaengshi.backend.domain.member.Member;
+import com.woohaengshi.backend.domain.member.State;
+import com.woohaengshi.backend.support.RepositoryTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@RepositoryTest
+public class StudyRecordRepositoryTest {
+
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private StudySubjectRepository studySubjectRepository;
+    @Autowired private SubjectRepository subjectRepository;
+    @Autowired private StudyRecordRepository studyRecordRepository;
+
+    @BeforeEach
+    public void setUp() {
+        Member member =
+                Member.builder()
+                        .id(100L)
+                        .password("pwd")
+                        .course(Course.CLOUD_SERVICE)
+                        .email("dd@Naver")
+                        .name("si")
+                        .state(State.ACTIVE)
+                        .sleepDate(LocalDate.now())
+                        .createdAt(LocalDateTime.now())
+                        .build();
+        memberRepository.save(member);
+
+        LocalDate date1 = LocalDate.of(2024, 8, 10);
+        LocalDate date2 = LocalDate.of(2024, 8, 11);
+
+        StudyRecord studyRecord1 =
+                StudyRecord.builder().member(member).time(500).date(date1).build();
+        StudyRecord studyRecord2 =
+                StudyRecord.builder().member(member).time(600).date(date1).build();
+        StudyRecord studyRecord3 =
+                StudyRecord.builder().member(member).time(700).date(date1).build();
+        StudyRecord studyRecord4 =
+                StudyRecord.builder().member(member).time(300).date(date2).build();
+        StudyRecord studyRecord5 =
+                StudyRecord.builder().member(member).time(300).date(date2).build();
+        studyRecordRepository.save(studyRecord1);
+        studyRecordRepository.save(studyRecord2);
+        studyRecordRepository.save(studyRecord3);
+        studyRecordRepository.save(studyRecord4);
+        studyRecordRepository.save(studyRecord5);
+
+        Subject subject1 = Subject.builder().name("HTML").member(member).build();
+        Subject subject2 = Subject.builder().name("CSS").member(member).build();
+        Subject subject3 = Subject.builder().name("JS").member(member).build();
+        subjectRepository.save(subject1);
+        subjectRepository.save(subject2);
+        subjectRepository.save(subject3);
+
+        StudySubject studySubject1 =
+                StudySubject.builder().studyRecord(studyRecord1).subject(subject1).build();
+        StudySubject studySubject2 =
+                StudySubject.builder().studyRecord(studyRecord2).subject(subject2).build();
+        StudySubject studySubject3 =
+                StudySubject.builder().studyRecord(studyRecord3).subject(subject3).build();
+        StudySubject studySubject4 =
+                StudySubject.builder().studyRecord(studyRecord4).subject(subject2).build();
+        StudySubject studySubject5 =
+                StudySubject.builder().studyRecord(studyRecord5).subject(subject3).build();
+        studySubjectRepository.save(studySubject1);
+        studySubjectRepository.save(studySubject2);
+        studySubjectRepository.save(studySubject3);
+        studySubjectRepository.save(studySubject4);
+        studySubjectRepository.save(studySubject5);
+    }
+
+    @Test
+    @DisplayName("공부 기록이 일 별로 제대로 조회가 되는지 확인")
+    public void findStudyRecords() {
+        List<Object[]> result = studyRecordRepository.findByYearAndMonthAndMemberId(2024, 8, 100L);
+        List<Object[]> expected = new ArrayList<>();
+        expected.add(new Object[] {10, 500, 1L, "HTML"});
+        expected.add(new Object[] {10, 600, 1L, "CSS"});
+        expected.add(new Object[] {10, 700, 1L, "JS"});
+        expected.add(new Object[] {11, 300, 1L, "CSS"});
+        expected.add(new Object[] {11, 300, 1L, "JS"});
+
+        assertAll(
+                "response",
+                () -> assertThat(result.size()).isEqualTo(expected.size()),
+                () -> {
+                    for (int i = 0; i < result.size(); i++) {
+                        assertThat(result.get(i)[0]).isEqualTo(expected.get(i)[0]);
+                        assertThat(result.get(i)[1]).isEqualTo(expected.get(i)[1]);
+                        assertThat(result.get(i)[3]).isEqualTo(expected.get(i)[3]);
+                    }
+                });
+    }
+}

--- a/src/test/java/com/woohaengshi/backend/repository/StudyRecordRepositoryTest.java
+++ b/src/test/java/com/woohaengshi/backend/repository/StudyRecordRepositoryTest.java
@@ -1,5 +1,8 @@
 package com.woohaengshi.backend.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import com.woohaengshi.backend.domain.StudyRecord;
 import com.woohaengshi.backend.domain.StudySubject;
 import com.woohaengshi.backend.domain.Subject;
@@ -7,6 +10,7 @@ import com.woohaengshi.backend.domain.member.Course;
 import com.woohaengshi.backend.domain.member.Member;
 import com.woohaengshi.backend.domain.member.State;
 import com.woohaengshi.backend.support.RepositoryTest;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,9 +20,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @RepositoryTest
 public class StudyRecordRepositoryTest {

--- a/src/test/java/com/woohaengshi/backend/repository/StudyRecordRepositoryTest.java
+++ b/src/test/java/com/woohaengshi/backend/repository/StudyRecordRepositoryTest.java
@@ -1,26 +1,21 @@
 package com.woohaengshi.backend.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import com.woohaengshi.backend.domain.StudyRecord;
 import com.woohaengshi.backend.domain.StudySubject;
 import com.woohaengshi.backend.domain.Subject;
-import com.woohaengshi.backend.domain.member.Course;
 import com.woohaengshi.backend.domain.member.Member;
-import com.woohaengshi.backend.domain.member.State;
 import com.woohaengshi.backend.support.RepositoryTest;
 import com.woohaengshi.backend.support.fixture.MemberFixture;
-import com.woohaengshi.backend.support.fixture.StudyRecordFixture;
-import org.junit.jupiter.api.BeforeEach;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @RepositoryTest
 public class StudyRecordRepositoryTest {

--- a/src/test/java/com/woohaengshi/backend/service/StudyRecordServiceImplTest.java
+++ b/src/test/java/com/woohaengshi/backend/service/StudyRecordServiceImplTest.java
@@ -18,6 +18,7 @@ import com.woohaengshi.backend.exception.WoohaengshiException;
 import com.woohaengshi.backend.repository.MemberRepository;
 import com.woohaengshi.backend.repository.StudyRecordRepository;
 import com.woohaengshi.backend.repository.SubjectRepository;
+import com.woohaengshi.backend.service.studyrecord.StudyRecordServiceImpl;
 import com.woohaengshi.backend.support.fixture.MemberFixture;
 import com.woohaengshi.backend.support.fixture.StudyRecordFixture;
 
@@ -32,11 +33,11 @@ import java.util.List;
 import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
-class StudyRecordServiceTest {
+class StudyRecordServiceImplTest {
     @Mock private MemberRepository memberRepository;
     @Mock private StudyRecordRepository studyRecordRepository;
     @Mock private SubjectRepository subjectRepository;
-    @InjectMocks private StudyRecordService studyRecordService;
+    @InjectMocks private StudyRecordServiceImpl studyRecordServiceImpl;
 
     @Test
     void 첫_공부_기록을_저장할_수_있다() {
@@ -58,7 +59,7 @@ class StudyRecordServiceTest {
                         });
 
         assertAll(
-                () -> studyRecordService.save(request, member.getId()),
+                () -> studyRecordServiceImpl.save(request, member.getId()),
                 () ->
                         verify(studyRecordRepository, times(1))
                                 .findByDateAndMemberId(request.getDate(), member.getId()),
@@ -88,7 +89,7 @@ class StudyRecordServiceTest {
                                     .willReturn(false);
                         });
         assertAll(
-                () -> studyRecordService.save(request, member.getId()),
+                () -> studyRecordServiceImpl.save(request, member.getId()),
                 () -> assertThat(existStudyRecord.getTime()).isEqualTo(30),
                 () ->
                         verify(studyRecordRepository, times(1))
@@ -113,7 +114,7 @@ class StudyRecordServiceTest {
                         subjectRepository.existsByNameAndStudyRecordId(
                                 DUPLICATED_SUBJECT, newStudyRecord.getId()))
                 .willReturn(true);
-        studyRecordService.save(request, member.getId());
+        studyRecordServiceImpl.save(request, member.getId());
         assertAll(() -> verify(subjectRepository, never()).save(any(Subject.class)));
     }
 
@@ -127,7 +128,7 @@ class StudyRecordServiceTest {
         given(memberRepository.findById(member.getId())).willReturn(Optional.empty());
         assertAll(
                 () ->
-                        assertThatThrownBy(() -> studyRecordService.save(request, member.getId()))
+                        assertThatThrownBy(() -> studyRecordServiceImpl.save(request, member.getId()))
                                 .isExactlyInstanceOf(WoohaengshiException.class),
                 () ->
                         verify(studyRecordRepository, times(1))

--- a/src/test/java/com/woohaengshi/backend/service/StudyRecordServiceTest.java
+++ b/src/test/java/com/woohaengshi/backend/service/StudyRecordServiceTest.java
@@ -33,11 +33,11 @@ import java.util.List;
 import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
-class StudyRecordServiceImplTest {
+class StudyRecordServiceTest {
     @Mock private MemberRepository memberRepository;
     @Mock private StudyRecordRepository studyRecordRepository;
     @Mock private SubjectRepository subjectRepository;
-    @InjectMocks private StudyRecordServiceImpl studyRecordServiceImpl;
+    @InjectMocks private StudyRecordServiceImpl studyRecordService;
 
     @Test
     void 첫_공부_기록을_저장할_수_있다() {
@@ -59,7 +59,7 @@ class StudyRecordServiceImplTest {
                         });
 
         assertAll(
-                () -> studyRecordServiceImpl.save(request, member.getId()),
+                () -> studyRecordService.save(request, member.getId()),
                 () ->
                         verify(studyRecordRepository, times(1))
                                 .findByDateAndMemberId(request.getDate(), member.getId()),
@@ -89,7 +89,7 @@ class StudyRecordServiceImplTest {
                                     .willReturn(false);
                         });
         assertAll(
-                () -> studyRecordServiceImpl.save(request, member.getId()),
+                () -> studyRecordService.save(request, member.getId()),
                 () -> assertThat(existStudyRecord.getTime()).isEqualTo(30),
                 () ->
                         verify(studyRecordRepository, times(1))
@@ -114,7 +114,7 @@ class StudyRecordServiceImplTest {
                         subjectRepository.existsByNameAndStudyRecordId(
                                 DUPLICATED_SUBJECT, newStudyRecord.getId()))
                 .willReturn(true);
-        studyRecordServiceImpl.save(request, member.getId());
+        studyRecordService.save(request, member.getId());
         assertAll(() -> verify(subjectRepository, never()).save(any(Subject.class)));
     }
 
@@ -128,7 +128,7 @@ class StudyRecordServiceImplTest {
         given(memberRepository.findById(member.getId())).willReturn(Optional.empty());
         assertAll(
                 () ->
-                        assertThatThrownBy(() -> studyRecordServiceImpl.save(request, member.getId()))
+                        assertThatThrownBy(() -> studyRecordService.save(request, member.getId()))
                                 .isExactlyInstanceOf(WoohaengshiException.class),
                 () ->
                         verify(studyRecordRepository, times(1))

--- a/src/test/java/com/woohaengshi/backend/service/StudyRecordServiceTest.java
+++ b/src/test/java/com/woohaengshi/backend/service/StudyRecordServiceTest.java
@@ -32,6 +32,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -146,7 +147,7 @@ class StudyRecordServiceTest {
     }
 
     @Test
-    void 연도와_월을_통해_공부_기록을_조회_한다() {
+    void 현재_연도와_월을_통해_공부_기록을_조회_한다() {
         Member member = MemberFixture.builder().build();
         List<Object[]> records = new ArrayList<>();
         records.add(new Object[] {1, 36000, 2L, "CSS"});
@@ -154,6 +155,7 @@ class StudyRecordServiceTest {
         records.add(new Object[] {6, 58000, 3L, "JS"});
         records.add(new Object[] {9, 47000, 3L, "JS"});
         records.add(new Object[] {9, 47000, 2L, "CSS"});
+        YearMonth date = YearMonth.now();
 
         ShowMonthlyRecordResponse expected = ShowMonthlyRecordResponse.of(2024, 8, records);
 
@@ -162,8 +164,7 @@ class StudyRecordServiceTest {
                 .willReturn(records);
 
         ShowMonthlyRecordResponse response =
-                studyRecordService.showMonthlyRecord(
-                        expected.getYear(), expected.getMonth(), member.getId());
+                studyRecordService.showMonthlyRecord(date, member.getId());
 
         assertAll(
                 "response",

--- a/src/test/java/com/woohaengshi/backend/service/TimerServiceTest.java
+++ b/src/test/java/com/woohaengshi/backend/service/TimerServiceTest.java
@@ -7,7 +7,7 @@ import static org.mockito.BDDMockito.given;
 import com.woohaengshi.backend.domain.StudyRecord;
 import com.woohaengshi.backend.domain.Subject;
 import com.woohaengshi.backend.domain.member.Member;
-import com.woohaengshi.backend.dto.response.studyrecord.ShowTimerResponse;
+import com.woohaengshi.backend.dto.response.timer.ShowTimerResponse;
 import com.woohaengshi.backend.exception.ErrorCode;
 import com.woohaengshi.backend.exception.WoohaengshiException;
 import com.woohaengshi.backend.repository.MemberRepository;

--- a/src/test/java/com/woohaengshi/backend/support/fixture/MemberFixture.java
+++ b/src/test/java/com/woohaengshi/backend/support/fixture/MemberFixture.java
@@ -4,6 +4,9 @@ import com.woohaengshi.backend.domain.member.Course;
 import com.woohaengshi.backend.domain.member.Member;
 import com.woohaengshi.backend.domain.member.State;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 public class MemberFixture {
 
     private Long id;
@@ -13,6 +16,8 @@ public class MemberFixture {
     private Course course = Course.CLOUD_SERVICE;
     private State state = State.ACTIVE;
     private String image = "https://image.com/virtual.png";
+    private LocalDateTime createdAt = LocalDateTime.now();
+    private LocalDate sleepDate = LocalDate.now();
 
     public static MemberFixture builder() {
         return new MemberFixture();
@@ -53,7 +58,18 @@ public class MemberFixture {
         return this;
     }
 
+    public MemberFixture createdAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+
+    public MemberFixture sleepDate(LocalDate sleepDate) {
+        this.sleepDate = sleepDate;
+        return this;
+    }
+
     public Member build() {
-        return Member.builder().id(id).email(email).name(name).image(image).state(state).build();
+        return Member.builder().id(id).email(email).name(name).image(image).state(state).course(course).password(password).
+        createdAt(createdAt).sleepDate(sleepDate).build();
     }
 }

--- a/src/test/java/com/woohaengshi/backend/support/fixture/MemberFixture.java
+++ b/src/test/java/com/woohaengshi/backend/support/fixture/MemberFixture.java
@@ -69,7 +69,16 @@ public class MemberFixture {
     }
 
     public Member build() {
-        return Member.builder().id(id).email(email).name(name).image(image).state(state).course(course).password(password).
-        createdAt(createdAt).sleepDate(sleepDate).build();
+        return Member.builder()
+                .id(id)
+                .email(email)
+                .name(name)
+                .image(image)
+                .state(state)
+                .course(course)
+                .password(password)
+                .createdAt(createdAt)
+                .sleepDate(sleepDate)
+                .build();
     }
 }


### PR DESCRIPTION
# 📄 Work Description
- 캘린더 월 별 공부 기록 조회 기능 추가

# ⚙️ ISSUE
- closed #23

# 📷 Screenshot
- 포스트맨
<img width="1015" alt="스크린샷 2024-08-12 오후 2 29 07" src="https://github.com/user-attachments/assets/56d38a22-b5a8-4e2e-bf17-ef71e23697f1">

<details>
<summary>전체 결과 보기</summary>

```json
{
    "year": 2024,
    "month": 8,
    "daily": [
        {
            "day": 2,
            "time": 20000,
            "subjects": [
                {
                    "id": 4,
                    "name": "JS"
                }
            ]
        },
        {
            "day": 10,
            "time": 20000,
            "subjects": [
                {
                    "id": 6,
                    "name": "CSS"
                }
            ]
        },
        {
            "day": 12,
            "time": 50000,
            "subjects": [
                {
                    "id": 1,
                    "name": "HTML"
                }
            ]
        },
        {
            "day": 12,
            "time": 20000,
            "subjects": [
                {
                    "id": 4,
                    "name": "JS"
                }
            ]
        }
    ]
}
```
</details>


# 💬 To Reviewers
일단 native query 를 사용했습니다. `month()` 와 `year()` 함수가 jpa 로 사용이 불가하다고 알고 있어서.. 🥲
혹시 더 깔끔하게 수정할 수 있는 방법을 아시면 추천 부탁드립니다.