### PR TITLE
[FIX] 정렬 기준 제거

### DIFF
--- a/src/main/java/com/woohaengshi/backend/repository/SubjectRepository.java
+++ b/src/main/java/com/woohaengshi/backend/repository/SubjectRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface SubjectRepository extends JpaRepository<Subject, Long> {
-    List<Subject> findAllByMemberIdOrderByNameAsc(Long memberId);
+    List<Subject> findAllByMemberId(Long memberId);
 
     boolean existsByMemberIdAndName(Long memberId, String name);
 }

--- a/src/main/java/com/woohaengshi/backend/service/timer/TimerServiceImpl.java
+++ b/src/main/java/com/woohaengshi/backend/service/timer/TimerServiceImpl.java
@@ -32,7 +32,7 @@ public class TimerServiceImpl implements TimerService {
     @Transactional(readOnly = true)
     public ShowTimerResponse getTimer(Long memberId) {
         validateExistMember(memberId);
-        List<Subject> subjects = subjectRepository.findAllByMemberIdOrderByNameAsc(memberId);
+        List<Subject> subjects = subjectRepository.findAllByMemberId(memberId);
         int todayStudyTime = getTodayStudyTime(memberId, getTodayDate());
         return ShowTimerResponse.of(todayStudyTime, subjects);
     }

--- a/src/test/java/com/woohaengshi/backend/service/TimerServiceTest.java
+++ b/src/test/java/com/woohaengshi/backend/service/TimerServiceTest.java
@@ -41,8 +41,7 @@ public class TimerServiceTest {
         List<Subject> subjects = List.of(subject1, subject2);
 
         given(memberRepository.existsById(member.getId())).willReturn(true);
-        given(subjectRepository.findAllByMemberId(member.getId()))
-                .willReturn(subjects);
+        given(subjectRepository.findAllByMemberId(member.getId())).willReturn(subjects);
         given(studyRecordRepository.findByDateAndMemberId(LocalDate.now(), member.getId()))
                 .willReturn(Optional.of(new StudyRecord(1L, 30, LocalDate.now(), member)));
 
@@ -70,8 +69,7 @@ public class TimerServiceTest {
         List<Subject> subjects = List.of(subject1, subject2);
 
         given(memberRepository.existsById(member.getId())).willReturn(true);
-        given(subjectRepository.findAllByMemberId(member.getId()))
-                .willReturn(subjects);
+        given(subjectRepository.findAllByMemberId(member.getId())).willReturn(subjects);
         given(studyRecordRepository.findByDateAndMemberId(LocalDate.now(), member.getId()))
                 .willReturn(Optional.empty());
 

--- a/src/test/java/com/woohaengshi/backend/service/TimerServiceTest.java
+++ b/src/test/java/com/woohaengshi/backend/service/TimerServiceTest.java
@@ -41,7 +41,7 @@ public class TimerServiceTest {
         List<Subject> subjects = List.of(subject1, subject2);
 
         given(memberRepository.existsById(member.getId())).willReturn(true);
-        given(subjectRepository.findAllByMemberIdOrderByNameAsc(member.getId()))
+        given(subjectRepository.findAllByMemberId(member.getId()))
                 .willReturn(subjects);
         given(studyRecordRepository.findByDateAndMemberId(LocalDate.now(), member.getId()))
                 .willReturn(Optional.of(new StudyRecord(1L, 30, LocalDate.now(), member)));
@@ -70,7 +70,7 @@ public class TimerServiceTest {
         List<Subject> subjects = List.of(subject1, subject2);
 
         given(memberRepository.existsById(member.getId())).willReturn(true);
-        given(subjectRepository.findAllByMemberIdOrderByNameAsc(member.getId()))
+        given(subjectRepository.findAllByMemberId(member.getId()))
                 .willReturn(subjects);
         given(studyRecordRepository.findByDateAndMemberId(LocalDate.now(), member.getId()))
                 .willReturn(Optional.empty());


### PR DESCRIPTION
# 📄 Work Description
- 타이머 조회 시 과목 정렬 기준 제거

# ⚙️ ISSUE
- closed #57 


# 💬 To Reviewers
프론트와 이야기 결과 과목 정렬 없는 게 낫다고 해서 정렬 제거했습니다.
