### PR TITLE
[FEAT] 캘린더 월 조회 api 수정

### DIFF
--- a/src/main/java/com/woohaengshi/backend/domain/StudyRecord.java
+++ b/src/main/java/com/woohaengshi/backend/domain/StudyRecord.java
@@ -2,19 +2,13 @@ package com.woohaengshi.backend.domain;
 
 import com.woohaengshi.backend.domain.member.Member;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Entity
 @Getter
@@ -33,6 +27,9 @@ public class StudyRecord {
     @JoinColumn(name = "member_id", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
+
+    @OneToMany(mappedBy = "studyRecord")
+    private List<StudySubject> studySubjects;
 
     protected StudyRecord() {}
 

--- a/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
@@ -1,12 +1,16 @@
 package com.woohaengshi.backend.dto.response.studyrecord;
 
-import com.woohaengshi.backend.domain.subject.Subject;
 import com.woohaengshi.backend.dto.response.subject.ShowSubjectsResponse;
 
+import com.woohaengshi.backend.dto.result.DailyStudyRecordResult;
 import lombok.Getter;
 
 import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 @Getter
 public class ShowMonthlyRecordResponse {
@@ -20,22 +24,25 @@ public class ShowMonthlyRecordResponse {
         this.records = records;
     }
 
-    public static ShowMonthlyRecordResponse of(YearMonth date, List<Object[]> records) {
-        return new ShowMonthlyRecordResponse(
-                date.getYear(),
-                date.getMonthValue(),
-                records.stream()
-                        .map(
-                                record ->
-                                        ShowDailyRecordResponse.of(
-                                                ((Number) record[0]).intValue(),
-                                                ((Number) record[1]).intValue(),
-                                                List.of(
-                                                        ShowSubjectsResponse.from(
-                                                                Subject.builder()
-                                                                        .id((Long) record[2])
-                                                                        .name((String) record[3])
-                                                                        .build()))))
-                        .toList());
+    public static ShowMonthlyRecordResponse of(
+            YearMonth date, List<DailyStudyRecordResult> results) {
+        Map<Integer, List<ShowSubjectsResponse>> subjectsMap = new HashMap<>();
+        Map<Integer, Integer> timeMap = new HashMap<>();
+
+        for (DailyStudyRecordResult result : results) {
+            subjectsMap
+                    .computeIfAbsent(result.getDay(), k -> new ArrayList<>())
+                    .add(ShowSubjectsResponse.of(result.getSubjectId(), result.getSubjectName()));
+            timeMap.putIfAbsent(result.getDay(), result.getTime());
+        }
+
+        List<ShowDailyRecordResponse> records = new ArrayList<>();
+        for (int day = 1; day <= date.lengthOfMonth(); day++) {
+            List<ShowSubjectsResponse> subjects = subjectsMap.getOrDefault(day, new ArrayList<>());
+            int time = timeMap.getOrDefault(day, 0);
+            records.add(ShowDailyRecordResponse.of(day, time, subjects));
+        }
+
+        return new ShowMonthlyRecordResponse(date.getYear(), date.getMonthValue(), records);
     }
 }

--- a/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
@@ -37,10 +37,12 @@ public class ShowMonthlyRecordResponse {
         }
 
         List<ShowDailyRecordResponse> records = new ArrayList<>();
-        for (int day = 1; day <= date.lengthOfMonth(); day++) {
-            List<ShowSubjectsResponse> subjects = subjectsMap.getOrDefault(day, new ArrayList<>());
-            records.add(ShowDailyRecordResponse.of(day, timeMap.getOrDefault(day, 0), subjects));
-        }
+        for (int day = 1; day <= date.lengthOfMonth(); day++)
+            records.add(
+                    ShowDailyRecordResponse.of(
+                            day,
+                            timeMap.getOrDefault(day, 0),
+                            subjectsMap.getOrDefault(day, new ArrayList<>())));
 
         return new ShowMonthlyRecordResponse(date.getYear(), date.getMonthValue(), records);
     }

--- a/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
@@ -39,8 +39,7 @@ public class ShowMonthlyRecordResponse {
         List<ShowDailyRecordResponse> records = new ArrayList<>();
         for (int day = 1; day <= date.lengthOfMonth(); day++) {
             List<ShowSubjectsResponse> subjects = subjectsMap.getOrDefault(day, new ArrayList<>());
-            int time = timeMap.getOrDefault(day, 0);
-            records.add(ShowDailyRecordResponse.of(day, time, subjects));
+            records.add(ShowDailyRecordResponse.of(day, timeMap.getOrDefault(day, 0), subjects));
         }
 
         return new ShowMonthlyRecordResponse(date.getYear(), date.getMonthValue(), records);

--- a/src/main/java/com/woohaengshi/backend/dto/response/subject/ShowSubjectsResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/subject/ShowSubjectsResponse.java
@@ -1,6 +1,5 @@
 package com.woohaengshi.backend.dto.response.subject;
 
-
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/woohaengshi/backend/dto/response/subject/ShowSubjectsResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/subject/ShowSubjectsResponse.java
@@ -16,7 +16,7 @@ public class ShowSubjectsResponse {
         this.name = name;
     }
 
-    public static ShowSubjectsResponse from(Subject subject) {
-        return new ShowSubjectsResponse(subject.getId(), subject.getName());
+    public static ShowSubjectsResponse of(Long id, String name) {
+        return new ShowSubjectsResponse(id, name);
     }
 }

--- a/src/main/java/com/woohaengshi/backend/dto/response/timer/ShowTimerResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/timer/ShowTimerResponse.java
@@ -21,6 +21,9 @@ public class ShowTimerResponse {
 
     public static ShowTimerResponse of(int time, List<Subject> subjects) {
         return new ShowTimerResponse(
-                time, subjects.stream().map(ShowSubjectsResponse::from).toList());
+                time,
+                subjects.stream()
+                        .map(subject -> ShowSubjectsResponse.of(subject.getId(), subject.getName()))
+                        .toList());
     }
 }

--- a/src/main/java/com/woohaengshi/backend/dto/result/DailyStudyRecordResult.java
+++ b/src/main/java/com/woohaengshi/backend/dto/result/DailyStudyRecordResult.java
@@ -1,0 +1,18 @@
+package com.woohaengshi.backend.dto.result;
+
+import lombok.Getter;
+
+@Getter
+public class DailyStudyRecordResult {
+    private int day;
+    private int time;
+    private Long subjectId;
+    private String subjectName;
+
+    public DailyStudyRecordResult(int day, int time, Long subjectId, String subjectName) {
+        this.day = day;
+        this.time = time;
+        this.subjectId = subjectId;
+        this.subjectName = subjectName;
+    }
+}

--- a/src/main/java/com/woohaengshi/backend/repository/StudyRecordRepository.java
+++ b/src/main/java/com/woohaengshi/backend/repository/StudyRecordRepository.java
@@ -1,6 +1,7 @@
 package com.woohaengshi.backend.repository;
 
 import com.woohaengshi.backend.domain.StudyRecord;
+import com.woohaengshi.backend.dto.result.DailyStudyRecordResult;
 import com.woohaengshi.backend.dto.result.MonthlyTotalRecordResult;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,20 +18,17 @@ public interface StudyRecordRepository
     Optional<StudyRecord> findByDateAndMemberId(LocalDate date, Long memberId);
 
     @Query(
-            value =
-                    "SELECT DAY(r.date), r.time, sb.id, sb.name\n"
-                            + "FROM study_record r\n"
-                            + "INNER JOIN study_subject st ON r.id = st.study_record_id\n"
-                            + "INNER JOIN subject sb ON st.subject_id = sb.id\n"
-                            + "WHERE YEAR(r.date) = :year\n"
-                            + "  AND MONTH(r.date) = :month\n"
-                            + "  AND r.member_id = :memberId\n"
-                            + "ORDER BY r.date ASC;",
-            nativeQuery = true)
-    List<Object[]> findByYearAndMonthAndMemberId(
-            @Param(value = "year") int year,
-            @Param(value = "month") int month,
-            @Param(value = "memberId") Long memberId);
+            "select new com.woohaengshi.backend.dto.result.DailyStudyRecordResult("
+                    + "DAY(sr.date), sr.time, sb.id, sb.name) "
+                    + "FROM StudyRecord sr "
+                    + "JOIN sr.studySubjects ss "
+                    + "JOIN ss.subject sb "
+                    + "WHERE YEAR(sr.date) = :year "
+                    + "AND MONTH(sr.date) = :month "
+                    + "AND sr.member.id = :memberId "
+                    + "ORDER BY sr.date, sr.id")
+    List<DailyStudyRecordResult> findByYearAndMonthAndMemberId(
+            @Param("year") int year, @Param("month") int month, @Param("memberId") Long memberId);
 
     @Query("SELECT COUNT(s) + 1 FROM StudyRecord s WHERE s.date = :date AND s.time > :time")
     Integer findRankByDate(LocalDate date, int time);

--- a/src/test/java/com/woohaengshi/backend/repository/StudyRecordRepositoryTest.java
+++ b/src/test/java/com/woohaengshi/backend/repository/StudyRecordRepositoryTest.java
@@ -7,6 +7,7 @@ import com.woohaengshi.backend.domain.StudyRecord;
 import com.woohaengshi.backend.domain.StudySubject;
 import com.woohaengshi.backend.domain.member.Member;
 import com.woohaengshi.backend.domain.subject.Subject;
+import com.woohaengshi.backend.dto.result.DailyStudyRecordResult;
 import com.woohaengshi.backend.dto.result.MonthlyTotalRecordResult;
 import com.woohaengshi.backend.support.RepositoryTest;
 import com.woohaengshi.backend.support.fixture.MemberFixture;
@@ -58,20 +59,20 @@ public class StudyRecordRepositoryTest {
         StudySubject studySubject2 =
                 저장(StudySubject.builder().studyRecord(studyRecord2).subject(subject).build());
 
-        List<Object[]> result1 =
+        List<DailyStudyRecordResult> result1 =
                 studyRecordRepository.findByYearAndMonthAndMemberId(2024, 1, member.getId());
 
         assertAll(
                 "response",
                 () -> assertThat(result1.size()).isEqualTo(1),
                 () ->
-                        assertThat(((Number) result1.get(0)[0]).intValue())
+                        assertThat(result1.get(0).getDay())
                                 .isEqualTo(date1.getDayOfMonth()),
                 () ->
-                        assertThat(((Number) result1.get(0)[1]).intValue())
+                        assertThat(result1.get(0).getTime())
                                 .isEqualTo(studyRecord1.getTime()),
-                () -> assertThat((Long) result1.get(0)[2]).isEqualTo(subject.getId()),
-                () -> assertThat((String) result1.get(0)[3]).isEqualTo(subject.getName()));
+                () -> assertThat(result1.get(0).getSubjectId()).isEqualTo(subject.getId()),
+                () -> assertThat(result1.get(0).getSubjectName()).isEqualTo(subject.getName()));
     }
 
     @Test

--- a/src/test/java/com/woohaengshi/backend/service/StudyRecordServiceTest.java
+++ b/src/test/java/com/woohaengshi/backend/service/StudyRecordServiceTest.java
@@ -17,6 +17,7 @@ import com.woohaengshi.backend.dto.request.studyrecord.SaveRecordRequest;
 import com.woohaengshi.backend.dto.response.studyrecord.ShowDailyRecordResponse;
 import com.woohaengshi.backend.dto.response.studyrecord.ShowMonthlyRecordResponse;
 import com.woohaengshi.backend.dto.response.studyrecord.ShowYearlyRecordResponse;
+import com.woohaengshi.backend.dto.result.DailyStudyRecordResult;
 import com.woohaengshi.backend.dto.result.MonthlyTotalRecordResult;
 import com.woohaengshi.backend.exception.WoohaengshiException;
 import com.woohaengshi.backend.repository.MemberRepository;
@@ -151,12 +152,10 @@ class StudyRecordServiceTest {
     @Test
     void 현재_연도와_월을_통해_공부_기록을_조회_한다() {
         Member member = MemberFixture.builder().build();
-        List<Object[]> records = new ArrayList<>();
-        records.add(new Object[] {1, 36000, 2L, "CSS"});
-        records.add(new Object[] {1, 36000, 1L, "HTML"});
-        records.add(new Object[] {6, 58000, 3L, "JS"});
-        records.add(new Object[] {9, 47000, 3L, "JS"});
-        records.add(new Object[] {9, 47000, 2L, "CSS"});
+        List<DailyStudyRecordResult> records = new ArrayList<>();
+        records.add(new DailyStudyRecordResult(1, 36000, 1L, "HTML"));
+        records.add(new DailyStudyRecordResult(6, 58000, 3L, "JS"));
+        records.add(new DailyStudyRecordResult(6, 58000, 3L, "JS"));
         YearMonth date = YearMonth.now();
 
         ShowMonthlyRecordResponse expected = ShowMonthlyRecordResponse.of(date, records);


### PR DESCRIPTION
# 📄 Work Description
- 캘린더 월 조회 api 수정
  - 공부 기록이 존재하지 않는 경우 time = 0, subjects = [ ] 로 저장
  - 공부 기록 중 과목이 여러 개일 경우 일 단위로 과목 데이터가 합쳐질 수 있도록 수정

# ⚙️ ISSUE
- closed #73 


# 📷 Screenshot
 - 포스트맨
<img width="1312" alt="스크린샷 2024-08-16 오후 11 00 53" src="https://github.com/user-attachments/assets/1f21f9e2-790e-405f-ab0f-76881b194b73">



# 💬 To Reviewers
아마 ShowMonthlyRecordResponse 부분의 코드가 복잡할텐데,
이 부분에 있어서 다른 깔끔한 방법이 있다면 알려주십쇼 .. 
일단 나름대로 깔끔하고 가독성 있게 작성하려고 노력해봤습니다 ^___^