### PR TITLE
[HOTFIX] 과목 조회 시 활성화된 과목만 조회하도록 수정

### DIFF
--- a/src/main/java/com/woohaengshi/backend/repository/SubjectRepository.java
+++ b/src/main/java/com/woohaengshi/backend/repository/SubjectRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface SubjectRepository extends JpaRepository<Subject, Long> {
-    List<Subject> findAllByMemberId(Long memberId);
+    List<Subject> findAllByMemberIdAndIsActiveTrue(Long memberId);
 
     Optional<Subject> findByMemberIdAndName(Long memberId, String name);
 

--- a/src/main/java/com/woohaengshi/backend/service/timer/TimerServiceImpl.java
+++ b/src/main/java/com/woohaengshi/backend/service/timer/TimerServiceImpl.java
@@ -32,7 +32,7 @@ public class TimerServiceImpl implements TimerService {
     @Transactional(readOnly = true)
     public ShowTimerResponse getTimer(Long memberId) {
         validateExistMember(memberId);
-        List<Subject> subjects = subjectRepository.findAllByMemberId(memberId);
+        List<Subject> subjects = subjectRepository.findAllByMemberIdAndIsActiveTrue(memberId);
         int todayStudyTime = getTodayStudyTime(memberId, getTodayDate());
         return ShowTimerResponse.of(todayStudyTime, subjects);
     }

--- a/src/test/java/com/woohaengshi/backend/service/TimerServiceTest.java
+++ b/src/test/java/com/woohaengshi/backend/service/TimerServiceTest.java
@@ -41,7 +41,7 @@ public class TimerServiceTest {
         List<Subject> subjects = List.of(subject1, subject2);
 
         given(memberRepository.existsById(member.getId())).willReturn(true);
-        given(subjectRepository.findAllByMemberId(member.getId())).willReturn(subjects);
+        given(subjectRepository.findAllByMemberIdAndIsActiveTrue(member.getId())).willReturn(subjects);
         given(studyRecordRepository.findByDateAndMemberId(LocalDate.now(), member.getId()))
                 .willReturn(Optional.of(new StudyRecord(1L, 30, LocalDate.now(), member)));
 
@@ -69,7 +69,7 @@ public class TimerServiceTest {
         List<Subject> subjects = List.of(subject1, subject2);
 
         given(memberRepository.existsById(member.getId())).willReturn(true);
-        given(subjectRepository.findAllByMemberId(member.getId())).willReturn(subjects);
+        given(subjectRepository.findAllByMemberIdAndIsActiveTrue(member.getId())).willReturn(subjects);
         given(studyRecordRepository.findByDateAndMemberId(LocalDate.now(), member.getId()))
                 .willReturn(Optional.empty());
 

--- a/src/test/java/com/woohaengshi/backend/service/TimerServiceTest.java
+++ b/src/test/java/com/woohaengshi/backend/service/TimerServiceTest.java
@@ -41,7 +41,8 @@ public class TimerServiceTest {
         List<Subject> subjects = List.of(subject1, subject2);
 
         given(memberRepository.existsById(member.getId())).willReturn(true);
-        given(subjectRepository.findAllByMemberIdAndIsActiveTrue(member.getId())).willReturn(subjects);
+        given(subjectRepository.findAllByMemberIdAndIsActiveTrue(member.getId()))
+                .willReturn(subjects);
         given(studyRecordRepository.findByDateAndMemberId(LocalDate.now(), member.getId()))
                 .willReturn(Optional.of(new StudyRecord(1L, 30, LocalDate.now(), member)));
 
@@ -69,7 +70,8 @@ public class TimerServiceTest {
         List<Subject> subjects = List.of(subject1, subject2);
 
         given(memberRepository.existsById(member.getId())).willReturn(true);
-        given(subjectRepository.findAllByMemberIdAndIsActiveTrue(member.getId())).willReturn(subjects);
+        given(subjectRepository.findAllByMemberIdAndIsActiveTrue(member.getId()))
+                .willReturn(subjects);
         given(studyRecordRepository.findByDateAndMemberId(LocalDate.now(), member.getId()))
                 .willReturn(Optional.empty());
 


### PR DESCRIPTION
# 📄 Work Description
- 과목 조회 시 활성화된 과목만 조회하도록 수정

# ⚙️ ISSUE
- closed #104 

# 💬 To Reviewers
아까 과목 삭제했는데도 자꾸 뜨던 이슈가 비활성화된 과목도 조회해서였습니다! 이 부분 수정했습니다.
