### PR TITLE
[FEAT] 캘린더 월 별 조회 api 수정

### DIFF
--- a/src/main/java/com/woohaengshi/backend/domain/StudyRecord.java
+++ b/src/main/java/com/woohaengshi/backend/domain/StudyRecord.java
@@ -28,6 +28,9 @@ public class StudyRecord {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
+    @Column(name = "comment")
+    private String comment;
+
     @OneToMany(mappedBy = "studyRecord")
     private List<StudySubject> studySubjects;
 

--- a/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowDailyRecordResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowDailyRecordResponse.java
@@ -11,11 +11,13 @@ import java.util.List;
 public class ShowDailyRecordResponse {
     private int day;
     private int time;
+    private String comment;
     private List<ShowSubjectsResponse> subjects;
 
-    private ShowDailyRecordResponse(int day, int time, List<ShowSubjectsResponse> subjects) {
+    private ShowDailyRecordResponse(int day, int time, String comment, List<ShowSubjectsResponse> subjects) {
         this.day = day;
         this.time = time;
+        this.comment = comment;
         this.subjects = subjects;
     }
 
@@ -23,6 +25,7 @@ public class ShowDailyRecordResponse {
         return new ShowDailyRecordResponse(
                 result.getDay(),
                 result.getTime(),
+                result.getComment(),
                 result.getSubjects().stream().map(ShowSubjectsResponse::from).toList());
     }
 }

--- a/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowDailyRecordResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowDailyRecordResponse.java
@@ -14,7 +14,8 @@ public class ShowDailyRecordResponse {
     private String comment;
     private List<ShowSubjectsResponse> subjects;
 
-    private ShowDailyRecordResponse(int day, int time, String comment, List<ShowSubjectsResponse> subjects) {
+    private ShowDailyRecordResponse(
+            int day, int time, String comment, List<ShowSubjectsResponse> subjects) {
         this.day = day;
         this.time = time;
         this.comment = comment;

--- a/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
+++ b/src/main/java/com/woohaengshi/backend/dto/response/studyrecord/ShowMonthlyRecordResponse.java
@@ -1,5 +1,7 @@
 package com.woohaengshi.backend.dto.response.studyrecord;
 
+import com.woohaengshi.backend.domain.subject.Subject;
+import com.woohaengshi.backend.dto.response.subject.ShowSubjectsResponse;
 import com.woohaengshi.backend.dto.result.ShowCalendarResult;
 
 import lombok.Getter;
@@ -13,19 +15,29 @@ public class ShowMonthlyRecordResponse {
     private int year;
     private int month;
     private List<ShowDailyRecordResponse> records;
+    private List<ShowSubjectsResponse> totalSubjects;
 
-    private ShowMonthlyRecordResponse(int year, int month, List<ShowDailyRecordResponse> records) {
+    private ShowMonthlyRecordResponse(
+            int year,
+            int month,
+            List<ShowDailyRecordResponse> records,
+            List<ShowSubjectsResponse> totalSubjects) {
         this.year = year;
         this.month = month;
         this.records = records;
+        this.totalSubjects = totalSubjects;
     }
 
     public static ShowMonthlyRecordResponse of(
-            YearMonth date, Map<Integer, ShowCalendarResult> calendar) {
+            YearMonth date, Map<Integer, ShowCalendarResult> calendar, List<Subject> subjects) {
         List<ShowDailyRecordResponse> records =
                 calendar.keySet().stream()
                         .map(result -> ShowDailyRecordResponse.from(calendar.get(result)))
                         .toList();
-        return new ShowMonthlyRecordResponse(date.getYear(), date.getMonthValue(), records);
+        return new ShowMonthlyRecordResponse(
+                date.getYear(),
+                date.getMonthValue(),
+                records,
+                subjects.stream().map(ShowSubjectsResponse::from).toList());
     }
 }

--- a/src/main/java/com/woohaengshi/backend/dto/result/ShowCalendarResult.java
+++ b/src/main/java/com/woohaengshi/backend/dto/result/ShowCalendarResult.java
@@ -16,9 +16,10 @@ public class ShowCalendarResult {
 
     private int day;
     private int time;
+    private String comment;
     private List<SubjectResult> subjects = new ArrayList<>();
 
     public static ShowCalendarResult init(int day) {
-        return new ShowCalendarResult(day, 0, new ArrayList<>());
+        return new ShowCalendarResult(day, 0, "", new ArrayList<>());
     }
 }

--- a/src/main/java/com/woohaengshi/backend/repository/studyrecord/StudyRecordCustomRepositoryImpl.java
+++ b/src/main/java/com/woohaengshi/backend/repository/studyrecord/StudyRecordCustomRepositoryImpl.java
@@ -38,6 +38,7 @@ public class StudyRecordCustomRepositoryImpl implements StudyRecordCustomReposit
                                                 ShowCalendarResult.class,
                                                 studyRecord.date.dayOfMonth(),
                                                 studyRecord.time,
+                                                studyRecord.comment,
                                                 list(
                                                         Projections.constructor(
                                                                         SubjectResult.class,

--- a/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
+++ b/src/main/java/com/woohaengshi/backend/service/studyrecord/StudyRecordServiceImpl.java
@@ -80,7 +80,10 @@ public class StudyRecordServiceImpl implements StudyRecordService {
                 studyRecordRepository.findStudyRecordInCalendar(
                         date.getYear(), date.getMonthValue(), memberId);
 
-        return ShowMonthlyRecordResponse.of(date, createCalendar(date, studyRecordInCalendar));
+        return ShowMonthlyRecordResponse.of(
+                date,
+                createCalendar(date, studyRecordInCalendar),
+                findSubjectsByMemberId(memberId));
     }
 
     private Map<Integer, ShowCalendarResult> createCalendar(
@@ -167,5 +170,9 @@ public class StudyRecordServiceImpl implements StudyRecordService {
         return memberRepository
                 .findById(memberId)
                 .orElseThrow(() -> new WoohaengshiException(MEMBER_NOT_FOUND));
+    }
+
+    private List<Subject> findSubjectsByMemberId(Long memberId) {
+        return subjectRepository.findAllByMemberIdAndIsActiveTrue(memberId);
     }
 }

--- a/src/main/resources/db/migration/V2__alter.sql
+++ b/src/main/resources/db/migration/V2__alter.sql
@@ -1,0 +1,1 @@
+ALTER TABLE study_record ADD COLUMN comment VARCHAR(2000);

--- a/src/main/resources/db/migration/V2__alter.sql
+++ b/src/main/resources/db/migration/V2__alter.sql
@@ -1,1 +1,0 @@
-ALTER TABLE study_record ADD COLUMN comment VARCHAR(2000);

--- a/src/main/resources/db/migration/V2__alterCommentToStudyRecord.sql
+++ b/src/main/resources/db/migration/V2__alterCommentToStudyRecord.sql
@@ -1,0 +1,1 @@
+ALTER TABLE study_record ADD COLUMN comment VARCHAR(2000);

--- a/src/test/java/com/woohaengshi/backend/service/StudyRecordServiceTest.java
+++ b/src/test/java/com/woohaengshi/backend/service/StudyRecordServiceTest.java
@@ -31,6 +31,7 @@ import com.woohaengshi.backend.support.fixture.MemberFixture;
 import com.woohaengshi.backend.support.fixture.StatisticsFixture;
 import com.woohaengshi.backend.support.fixture.StudyRecordFixture;
 
+import com.woohaengshi.backend.support.fixture.SubjectFixture;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -176,22 +177,29 @@ class StudyRecordServiceTest {
     @Test
     void 월_단위_공부_기록을_조회_할_수_있다() {
         YearMonth date = YearMonth.now();
+
         SubjectResult subjectResult1 = new SubjectResult(1L, "HTML");
         SubjectResult subjectResult2 = new SubjectResult(2L, "CSS");
         SubjectResult subjectResult3 = new SubjectResult(3L, "JAVA");
+
         ShowCalendarResult showCalendarResult1 =
                 new ShowCalendarResult(12, 10, List.of(subjectResult1, subjectResult2));
         ShowCalendarResult showCalendarResult2 =
                 new ShowCalendarResult(13, 100, List.of(subjectResult3));
         ShowCalendarResult showCalendarResult3 =
                 new ShowCalendarResult(14, 200, List.of(subjectResult1, subjectResult3));
+
         List<ShowCalendarResult> result =
                 List.of(showCalendarResult1, showCalendarResult2, showCalendarResult3);
+
         given(memberRepository.existsById(1L)).willReturn(true);
         given(
                         studyRecordRepository.findStudyRecordInCalendar(
                                 date.getYear(), date.getMonthValue(), 1L))
                 .willReturn(result);
+        given(subjectRepository.findAllByMemberIdAndIsActiveTrue(1L))
+                .willReturn(List.of(SubjectFixture.builder().build()));
+
         ShowMonthlyRecordResponse response = studyRecordService.getMonthlyRecord(date, 1L);
         assertAll(
                 () -> assertThat(response.getYear()).isEqualTo(date.getYear()),
@@ -208,7 +216,10 @@ class StudyRecordServiceTest {
                                 .isEqualTo(showCalendarResult2.getTime()),
                 () ->
                         assertThat(response.getRecords().get(13).getTime())
-                                .isEqualTo(showCalendarResult3.getTime()));
+                                .isEqualTo(showCalendarResult3.getTime()),
+                () ->
+                        assertThat(response.getTotalSubjects().get(0).getId())
+                                .isEqualTo(SubjectFixture.builder().build().getId()));
     }
 
     @Test

--- a/src/test/java/com/woohaengshi/backend/service/StudyRecordServiceTest.java
+++ b/src/test/java/com/woohaengshi/backend/service/StudyRecordServiceTest.java
@@ -30,8 +30,8 @@ import com.woohaengshi.backend.service.studyrecord.StudyRecordServiceImpl;
 import com.woohaengshi.backend.support.fixture.MemberFixture;
 import com.woohaengshi.backend.support.fixture.StatisticsFixture;
 import com.woohaengshi.backend.support.fixture.StudyRecordFixture;
-
 import com.woohaengshi.backend.support.fixture.SubjectFixture;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;

--- a/src/test/java/com/woohaengshi/backend/service/StudyRecordServiceTest.java
+++ b/src/test/java/com/woohaengshi/backend/service/StudyRecordServiceTest.java
@@ -183,11 +183,11 @@ class StudyRecordServiceTest {
         SubjectResult subjectResult3 = new SubjectResult(3L, "JAVA");
 
         ShowCalendarResult showCalendarResult1 =
-                new ShowCalendarResult(12, 10, List.of(subjectResult1, subjectResult2));
+                new ShowCalendarResult(12, 10, "1", List.of(subjectResult1, subjectResult2));
         ShowCalendarResult showCalendarResult2 =
-                new ShowCalendarResult(13, 100, List.of(subjectResult3));
+                new ShowCalendarResult(13, 100, "2", List.of(subjectResult3));
         ShowCalendarResult showCalendarResult3 =
-                new ShowCalendarResult(14, 200, List.of(subjectResult1, subjectResult3));
+                new ShowCalendarResult(14, 200, "3", List.of(subjectResult1, subjectResult3));
 
         List<ShowCalendarResult> result =
                 List.of(showCalendarResult1, showCalendarResult2, showCalendarResult3);
@@ -217,6 +217,9 @@ class StudyRecordServiceTest {
                 () ->
                         assertThat(response.getRecords().get(13).getTime())
                                 .isEqualTo(showCalendarResult3.getTime()),
+                () ->
+                        assertThat(response.getRecords().get(12).getComment())
+                                .isEqualTo(showCalendarResult1.getComment()),
                 () ->
                         assertThat(response.getTotalSubjects().get(0).getId())
                                 .isEqualTo(SubjectFixture.builder().build().getId()));


### PR DESCRIPTION
# 📄 Work Description
- 캘린더 조회 시 회원의 전체 과목 목록 함께 조회
- 캘린더 조회 시 일 별 회고 조회하는 부분 추가

# ⚙️ ISSUE
- closed #117 


# 📷 Screenshot
 - comment
<img width="1440" alt="스크린샷 2024-09-10 오후 3 01 28" src="https://github.com/user-attachments/assets/bb09b0d3-3531-4562-8a1e-014893abbfd3">
 - totalSubjects
<img width="1440" alt="스크린샷 2024-09-10 오후 3 02 12" src="https://github.com/user-attachments/assets/ed3a2890-28dd-4445-96dd-90d77892c1f2">

# 💬 To Reviewers
comment 는 일단 공부 기록이 없는 날은 ""로 데이터 넣었고,
추후 회고 추가 api 개발하면서 공부 기록이 저장되는 경우 회고가 ""로 들어가도록 해보려고 합니다.